### PR TITLE
lthash-rs improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 libsodium-sys = { version = "0.2", optional = true }
 thiserror = "1.0"
 zeroize = { version = "1", features = ["zeroize_derive"] }
+base64 = "0.22"
+
+[dev-dependencies]
+criterion = "0.5"
 
 [features]
 default = ["sodium"]
@@ -23,3 +27,11 @@ path = "src/bin/example.rs"
 [[bin]]
 name = "test_cross_compat"
 path = "src/bin/test_cross_compat.rs"
+
+[[bin]]
+name = "lthash"
+path = "src/bin/lthash_cli.rs"
+
+[[bench]]
+name = "lthash_bench"
+harness = false

--- a/benches/lthash_bench.rs
+++ b/benches/lthash_bench.rs
@@ -1,0 +1,188 @@
+//! Benchmarks for LtHash operations
+//!
+//! Run with: cargo bench
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use lthash::{Blake2xb, LtHash16_1024, LtHash20_1008, LtHash32_1024};
+
+/// Benchmark Blake2xb hash at various output sizes
+fn bench_blake2xb(c: &mut Criterion) {
+    let mut group = c.benchmark_group("blake2xb");
+
+    // Test data sizes
+    let input_sizes = [64, 256, 1024, 4096];
+
+    for input_size in input_sizes {
+        let input = vec![0xABu8; input_size];
+
+        // Benchmark 64-byte output (single block)
+        group.throughput(Throughput::Bytes(input_size as u64));
+        group.bench_function(format!("hash_{input_size}B_to_64B"), |b| {
+            let mut output = vec![0u8; 64];
+            b.iter(|| {
+                Blake2xb::hash(black_box(&mut output), black_box(&input), &[], &[], &[]).unwrap();
+            });
+        });
+
+        // Benchmark 2048-byte output (LtHash16_1024 size)
+        group.bench_function(format!("hash_{input_size}B_to_2048B"), |b| {
+            let mut output = vec![0u8; 2048];
+            b.iter(|| {
+                Blake2xb::hash(black_box(&mut output), black_box(&input), &[], &[], &[]).unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Benchmark LtHash add_object operations
+fn bench_lthash_add(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lthash_add");
+
+    // Test various object sizes
+    let object_sizes = [32, 128, 512, 1024];
+
+    for size in object_sizes {
+        let object = vec![0xCDu8; size];
+
+        // LtHash16_1024
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_function(format!("16_1024_add_{size}B"), |b| {
+            let mut hash = LtHash16_1024::new().unwrap();
+            b.iter(|| {
+                hash.add_object(black_box(&object)).unwrap();
+            });
+        });
+
+        // LtHash20_1008
+        group.bench_function(format!("20_1008_add_{size}B"), |b| {
+            let mut hash = LtHash20_1008::new().unwrap();
+            b.iter(|| {
+                hash.add_object(black_box(&object)).unwrap();
+            });
+        });
+
+        // LtHash32_1024
+        group.bench_function(format!("32_1024_add_{size}B"), |b| {
+            let mut hash = LtHash32_1024::new().unwrap();
+            b.iter(|| {
+                hash.add_object(black_box(&object)).unwrap();
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Benchmark LtHash homomorphic operations (combining hashes)
+fn bench_lthash_combine(c: &mut Criterion) {
+    let mut group = c.benchmark_group("lthash_combine");
+
+    // Setup: create two hashes with some data
+    let mut hash1 = LtHash16_1024::new().unwrap();
+    let mut hash2 = LtHash16_1024::new().unwrap();
+    hash1.add_object(b"test data 1").unwrap();
+    hash2.add_object(b"test data 2").unwrap();
+
+    // Benchmark try_add (non-panicking)
+    group.bench_function("16_1024_try_add", |b| {
+        let mut hash_a = hash1.clone();
+        b.iter(|| {
+            hash_a.try_add(black_box(&hash2)).unwrap();
+        });
+    });
+
+    // Benchmark try_sub (non-panicking)
+    group.bench_function("16_1024_try_sub", |b| {
+        let mut hash_a = hash1.clone();
+        b.iter(|| {
+            hash_a.try_sub(black_box(&hash2)).unwrap();
+        });
+    });
+
+    // Setup for LtHash32_1024
+    let mut hash1_32 = LtHash32_1024::new().unwrap();
+    let mut hash2_32 = LtHash32_1024::new().unwrap();
+    hash1_32.add_object(b"test data 1").unwrap();
+    hash2_32.add_object(b"test data 2").unwrap();
+
+    group.bench_function("32_1024_try_add", |b| {
+        let mut hash_a = hash1_32.clone();
+        b.iter(|| {
+            hash_a.try_add(black_box(&hash2_32)).unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+/// Benchmark checksum comparison (constant-time)
+fn bench_checksum_compare(c: &mut Criterion) {
+    let mut group = c.benchmark_group("checksum_compare");
+
+    let mut hash1 = LtHash16_1024::new().unwrap();
+    let mut hash2 = LtHash16_1024::new().unwrap();
+    hash1.add_object(b"same data").unwrap();
+    hash2.add_object(b"same data").unwrap();
+
+    let checksum = hash1.get_checksum().to_vec();
+
+    group.bench_function("16_1024_checksum_equals", |b| {
+        b.iter(|| {
+            hash1.checksum_equals(black_box(&checksum)).unwrap()
+        });
+    });
+
+    group.bench_function("16_1024_eq", |b| {
+        b.iter(|| {
+            black_box(&hash1) == black_box(&hash2)
+        });
+    });
+
+    group.finish();
+}
+
+/// Benchmark hash creation
+fn bench_creation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("creation");
+
+    group.bench_function("16_1024_new", |b| {
+        b.iter(|| {
+            LtHash16_1024::new().unwrap()
+        });
+    });
+
+    group.bench_function("20_1008_new", |b| {
+        b.iter(|| {
+            LtHash20_1008::new().unwrap()
+        });
+    });
+
+    group.bench_function("32_1024_new", |b| {
+        b.iter(|| {
+            LtHash32_1024::new().unwrap()
+        });
+    });
+
+    // With initial checksum
+    let checksum = vec![0u8; LtHash16_1024::checksum_size_bytes()];
+    group.bench_function("16_1024_with_checksum", |b| {
+        b.iter(|| {
+            LtHash16_1024::with_checksum(black_box(&checksum)).unwrap()
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_blake2xb,
+    bench_lthash_add,
+    bench_lthash_combine,
+    bench_checksum_compare,
+    bench_creation,
+);
+
+criterion_main!(benches);

--- a/src/bin/lthash_cli.rs
+++ b/src/bin/lthash_cli.rs
@@ -1,0 +1,191 @@
+//! LtHash Command Line Tool
+//!
+//! A Unix-friendly CLI for computing and combining LtHash checksums.
+//!
+//! # Usage
+//!
+//! ```bash
+//! # Hash a file
+//! lthash myfile.txt
+//!
+//! # Hash stdin
+//! cat myfile.txt | lthash -
+//!
+//! # Add a file to an existing hash
+//! lthash add <hash> myfile.txt
+//!
+//! # Subtract a file from an existing hash
+//! lthash sub <hash> myfile.txt
+//!
+//! # Piping: chain operations
+//! lthash file1.txt | lthash add - file2.txt | lthash add - file3.txt
+//! ```
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use lthash::LtHash16_1024;
+use std::env;
+use std::fs::File;
+use std::io::{self, BufReader, Read};
+use std::process;
+
+const USAGE: &str = r#"lthash - Homomorphic hash tool
+
+USAGE:
+    lthash [FILE]           Hash a file (or stdin with '-')
+    lthash add HASH [FILE]  Add file to existing hash
+    lthash sub HASH [FILE]  Subtract file from existing hash
+
+ARGUMENTS:
+    FILE    File to process (use '-' for stdin)
+    HASH    URL-safe base64 encoded hash (use '-' to read from stdin)
+
+EXAMPLES:
+    # Hash a file
+    lthash myfile.txt
+
+    # Hash stdin
+    echo "hello" | lthash -
+
+    # Combine hashes (piping)
+    lthash file1.txt | lthash add - file2.txt | lthash add - file3.txt
+
+    # Remove a file's contribution
+    lthash sub $COMBINED_HASH removed_file.txt
+
+OUTPUT:
+    Prints URL-safe base64 encoded hash to stdout (no padding, safe for CLI args)
+"#;
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("error: {}", e);
+        process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 2 {
+        eprintln!("{}", USAGE);
+        process::exit(1);
+    }
+
+    match args[1].as_str() {
+        "-h" | "--help" | "help" => {
+            println!("{}", USAGE);
+            Ok(())
+        }
+        "add" => {
+            if args.len() < 3 {
+                eprintln!("error: 'add' requires a hash argument");
+                eprintln!("usage: lthash add HASH [FILE]");
+                process::exit(1);
+            }
+            let hash_arg = &args[2];
+            let file_arg = args.get(3).map(|s| s.as_str()).unwrap_or("-");
+            cmd_add(hash_arg, file_arg)
+        }
+        "sub" => {
+            if args.len() < 3 {
+                eprintln!("error: 'sub' requires a hash argument");
+                eprintln!("usage: lthash sub HASH [FILE]");
+                process::exit(1);
+            }
+            let hash_arg = &args[2];
+            let file_arg = args.get(3).map(|s| s.as_str()).unwrap_or("-");
+            cmd_sub(hash_arg, file_arg)
+        }
+        file_arg => {
+            cmd_hash(file_arg)
+        }
+    }
+}
+
+/// Hash a single file and output base64 encoded hash
+fn cmd_hash(file_arg: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let data = read_file_data(file_arg)?;
+
+    let mut hash = LtHash16_1024::new()?;
+    hash.add_object(&data)?;
+
+    let encoded = URL_SAFE_NO_PAD.encode(hash.get_checksum());
+    println!("{}", encoded);
+
+    Ok(())
+}
+
+/// Add a file's hash to an existing hash
+fn cmd_add(hash_arg: &str, file_arg: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let existing_hash = read_hash(hash_arg)?;
+    let data = read_file_data(file_arg)?;
+
+    let mut hash = LtHash16_1024::with_checksum(&existing_hash)?;
+    hash.add_object(&data)?;
+
+    let encoded = URL_SAFE_NO_PAD.encode(hash.get_checksum());
+    println!("{}", encoded);
+
+    Ok(())
+}
+
+/// Subtract a file's hash from an existing hash
+fn cmd_sub(hash_arg: &str, file_arg: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let existing_hash = read_hash(hash_arg)?;
+    let data = read_file_data(file_arg)?;
+
+    let mut hash = LtHash16_1024::with_checksum(&existing_hash)?;
+    hash.remove_object(&data)?;
+
+    let encoded = URL_SAFE_NO_PAD.encode(hash.get_checksum());
+    println!("{}", encoded);
+
+    Ok(())
+}
+
+/// Read file data from a file path or stdin
+fn read_file_data(file_arg: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let mut data = Vec::new();
+
+    if file_arg == "-" {
+        io::stdin().read_to_end(&mut data)?;
+    } else {
+        let file = File::open(file_arg)
+            .map_err(|e| format!("cannot open '{}': {}", file_arg, e))?;
+        let mut reader = BufReader::new(file);
+        reader.read_to_end(&mut data)?;
+    }
+
+    Ok(data)
+}
+
+/// Read and decode a hash from argument or stdin
+fn read_hash(hash_arg: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let hash_str = if hash_arg == "-" {
+        // Read hash from stdin (trim whitespace)
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        input.trim().to_string()
+    } else {
+        hash_arg.to_string()
+    };
+
+    // Handle empty hash (start fresh)
+    if hash_str.is_empty() {
+        return Ok(vec![0u8; LtHash16_1024::checksum_size_bytes()]);
+    }
+
+    // Decode URL-safe base64
+    let decoded = URL_SAFE_NO_PAD.decode(&hash_str)
+        .map_err(|e| format!("invalid base64 hash: {}", e))?;
+
+    let expected_size = LtHash16_1024::checksum_size_bytes();
+    if decoded.len() != expected_size {
+        return Err(format!(
+            "invalid hash size: expected {} bytes, got {} bytes",
+            expected_size, decoded.len()
+        ).into());
+    }
+
+    Ok(decoded)
+}

--- a/src/blake2xb.rs
+++ b/src/blake2xb.rs
@@ -135,7 +135,7 @@ impl Blake2xb {
 
         if !key.is_empty() && key.len() > 64 {
             return Err(LtHashError::InvalidKeySize {
-                expected: "0-64 bytes".to_string(),
+                expected: "0-64 bytes",
                 actual: key.len(),
             });
         }
@@ -192,14 +192,10 @@ impl Blake2xb {
 
     pub fn update(&mut self, data: &[u8]) -> Result<(), LtHashError> {
         if !self.initialized {
-            return Err(LtHashError::NotInitialized {
-                method: "update".to_string(),
-            });
+            return Err(LtHashError::NotInitialized { method: "update" });
         }
         if self.finished {
-            return Err(LtHashError::AlreadyFinished {
-                method: "update".to_string(),
-            });
+            return Err(LtHashError::AlreadyFinished { method: "update" });
         }
 
         let result = unsafe {
@@ -208,7 +204,7 @@ impl Blake2xb {
 
         if result != 0 {
             return Err(LtHashError::Blake2Error(
-                "crypto_generichash_blake2b_update failed".to_string(),
+                "crypto_generichash_blake2b_update failed",
             ));
         }
 
@@ -217,22 +213,19 @@ impl Blake2xb {
 
     pub fn finish(&mut self, out: &mut [u8]) -> Result<(), LtHashError> {
         if !self.initialized {
-            return Err(LtHashError::NotInitialized {
-                method: "finish".to_string(),
-            });
+            return Err(LtHashError::NotInitialized { method: "finish" });
         }
         if self.finished {
-            return Err(LtHashError::AlreadyCalled("finish".to_string()));
+            return Err(LtHashError::AlreadyCalled("finish"));
         }
 
         if self.output_length_known {
             let expected_len = u32::from_le(self.param.xof_length) as usize;
             if expected_len != 0xffffffff && out.len() != expected_len {
-                return Err(LtHashError::Blake2Error(format!(
-                    "Output length mismatch: expected {}, got {}",
-                    expected_len,
-                    out.len()
-                )));
+                return Err(LtHashError::OutputSizeMismatch {
+                    expected: expected_len,
+                    actual: out.len(),
+                });
             }
         }
 
@@ -244,7 +237,7 @@ impl Blake2xb {
         if result != 0 {
             h0.zeroize(); // Securely clear h0 on error
             return Err(LtHashError::Blake2Error(
-                "crypto_generichash_blake2b_final failed".to_string(),
+                "crypto_generichash_blake2b_final failed",
             ));
         }
 
@@ -288,7 +281,7 @@ impl Blake2xb {
             if result != 0 {
                 h0.zeroize(); // Securely clear h0 on error
                 return Err(LtHashError::Blake2Error(
-                    "crypto_generichash_blake2b_update failed in expansion".to_string(),
+                    "crypto_generichash_blake2b_update failed in expansion",
                 ));
             }
 
@@ -304,7 +297,7 @@ impl Blake2xb {
             if result != 0 {
                 h0.zeroize(); // Securely clear h0 on error
                 return Err(LtHashError::Blake2Error(
-                    "crypto_generichash_blake2b_final failed in expansion".to_string(),
+                    "crypto_generichash_blake2b_final failed in expansion",
                 ));
             }
 
@@ -419,7 +412,7 @@ impl Blake2xb {
         if !key.is_empty() {
             if key.len() > 64 {
                 return Err(LtHashError::InvalidKeySize {
-                    expected: "0-64 bytes".to_string(),
+                    expected: "0-64 bytes",
                     actual: key.len(),
                 });
             }
@@ -437,7 +430,7 @@ impl Blake2xb {
 
             if result != 0 {
                 return Err(LtHashError::Blake2Error(
-                    "crypto_generichash_blake2b_update failed for key".to_string(),
+                    "crypto_generichash_blake2b_update failed for key",
                 ));
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum LtHashError {
     #[error("Invalid key size: expected {expected}, got {actual}")]
-    InvalidKeySize { expected: String, actual: usize },
+    InvalidKeySize { expected: &'static str, actual: usize },
 
     #[error("Invalid salt length: expected 16 bytes, got {0}")]
     InvalidSaltLength(usize),
@@ -24,14 +24,17 @@ pub enum LtHashError {
     InvalidChecksumPadding,
 
     #[error("Must call init() before calling {method}")]
-    NotInitialized { method: String },
+    NotInitialized { method: &'static str },
 
     #[error("Cannot call {method} after finish()")]
-    AlreadyFinished { method: String },
+    AlreadyFinished { method: &'static str },
 
     #[error("{0} already called")]
-    AlreadyCalled(String),
+    AlreadyCalled(&'static str),
 
     #[error("Blake2b operation failed: {0}")]
-    Blake2Error(String),
+    Blake2Error(&'static str),
+
+    #[error("Key mismatch: cannot combine LtHashes with different keys")]
+    KeyMismatch,
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a Unix-friendly `lthash` CLI and Criterion benchmarks, adds secure memory zeroing and alignment fixes, provides non-panicking combine APIs, switches to static error strings, and optimizes LtHash with a pre-allocated scratch buffer.
> 
> - **Features**
>   - **CLI (`src/bin/lthash_cli.rs`)**: `lthash` tool with `hash`, `add`, `sub`; supports stdin (`-`) and URL-safe base64 I/O.
>   - **Benchmarks (`benches/lthash_bench.rs`)**: Measure `Blake2xb`, add/sub/combine, checksum compare, and creation via `criterion`.
> - **Security**
>   - Add `zeroize` and securely clear keys, intermediate `h0`, and key blocks; use `#[must_use]` on critical methods.
>   - Fix unsafe u64 casting by using `align_to()` in `as_u64_slice[_mut]()`.
> - **API/Reliability**
>   - Add `LtHash::try_add()`/`try_sub()` returning `Result` with new `LtHashError::KeyMismatch`.
>   - Change error payloads to `&'static str`; introduce `OutputSizeMismatch`; document `Default` panic conditions.
> - **Performance**
>   - Introduce pre-allocated `scratch: Vec<u8>` in `LtHash`; `add_object`/`remove_object` hash into scratch to avoid per-call allocations.
> - **Config/Deps**
>   - Update `Cargo.toml`: add `zeroize`, `base64`, dev-dep `criterion`; add `[[bin]] lthash` and `[[bench]] lthash_bench` entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daeb7dc14f039bec0f2600a5ffc3a1a717105a36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->