### PR TITLE
Add KDF-based key derivation to set_key()

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -31,7 +31,7 @@ Rust implementation of Facebook's LtHash (Lattice-based Homomorphic Hash). Uses 
 3. **Secure clearing of intermediate hash** (`h0`, `key_block` in Blake2xb)
 4. **Secure clearing on drop** for all hasher structs and LtHash checksum/scratch
 5. **Padding bit validation** for 20-bit variant
-6. **Key size validation** (16-64 bytes)
+6. **Key derivation via KDF** - `set_key()` uses BLAKE3 derive_key to produce 32-byte keys
 7. **Safe alignment handling** using `align_to()` with assertions
 8. **`#[must_use]` attributes** on key methods to prevent ignored errors
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ fn main() -> Result<(), LtHashError> {
 
 ```rust
 let mut hash = LtHash16_1024::new()?;
-hash.set_key(b"my-secret-key-here")?;  // 16-64 bytes
+// Key material is run through BLAKE3 KDF to derive a 32-byte key
+hash.set_key(b"any-length-key-material")?;
 hash.add_object(b"sensitive data")?;
 // Key is securely zeroed on drop or clear_key()
 ```
@@ -112,7 +113,7 @@ impl LtHash<B, N> {
     fn get_checksum(&self) -> &[u8];
     fn checksum_size_bytes() -> usize;
 
-    fn set_key(&mut self, key: &[u8]) -> Result<(), LtHashError>;  // 16-64 bytes
+    fn set_key(&mut self, key: &[u8]) -> Result<(), LtHashError>;  // Any length, KDF-derived
     fn clear_key(&mut self);
 }
 

--- a/src/blake3_xof.rs
+++ b/src/blake3_xof.rs
@@ -93,13 +93,12 @@ impl Blake3Xof {
         let hasher = if key.is_empty() {
             blake3::Hasher::new()
         } else if key.len() == 32 {
-            // BLAKE3 requires exactly 32-byte keys
+            // Key should already be derived to 32 bytes by LtHash::set_key()
             let key_array: [u8; 32] = key.try_into().unwrap();
             blake3::Hasher::new_keyed(&key_array)
         } else {
-            // For non-32-byte keys, derive a 32-byte key using BLAKE3's derive_key
-            // This maintains security while supporting variable key lengths
-            let derived_key = blake3::derive_key("lthash-rs key derivation v1", key);
+            // Fallback for direct Blake3Xof usage with non-32-byte keys
+            let derived_key = blake3::derive_key("lthash-rs blake3xof key", key);
             blake3::Hasher::new_keyed(&derived_key)
         };
 


### PR DESCRIPTION
Security improvement: set_key() now uses BLAKE3's derive_key KDF to derive a uniform 32-byte key from arbitrary-length key material.

Changes:
- set_key() accepts any non-empty key material (BLAKE3 backend)
- Key material is derived through BLAKE3 KDF with domain separator
- Derived 32-byte key is stored and used for keyed hashing
- folly-compat mode keeps original behavior (16-64 byte raw keys) to maintain Facebook compatibility

This ensures uniform key distribution regardless of input key quality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> set_key now KDF-derives a fixed 32-byte key from arbitrary-length input on the BLAKE3 backend, while folly-compat retains 16–64 byte raw keys; docs and BLAKE3 XOF updated accordingly.
> 
> - **Core/API**:
>   - `LtHash::set_key()` (BLAKE3 backend): accept non-empty key material and derive a 32-byte key via `blake3::derive_key` (stores derived key); error on empty input.
>   - `LtHash::set_key()` (folly-compat): keep original 16–64 byte raw key validation/usage for byte-for-byte compatibility.
>   - Updated struct/docs to note keys are KDF-derived to 32 bytes.
> - **Hash Backend (BLAKE3 XOF)**:
>   - Expect 32-byte keys; for non-32-byte inputs, derive a key using a new domain string (`"lthash-rs blake3xof key"`).
> - **Docs**:
>   - README and analysis notes updated: examples now show arbitrary-length keys; security measures list includes KDF-based key derivation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d740bd264d52881738828fba836551b988dbae32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->