### PR TITLE
Add streaming API for large file support

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -68,6 +68,9 @@ Rust implementation of Facebook's LtHash (Lattice-based Homomorphic Hash). Uses 
 - Pre-allocated scratch buffer eliminates per-operation allocations
 - Split-lane arithmetic for 16-bit and 32-bit element packing
 - Manual Clone impl avoids unnecessary scratch buffer cloning
+- **Streaming API** for large files: `add_object_stream()` / `remove_object_stream()`
+  - Reads data in 8KB chunks, never loads entire file into memory
+  - CLI uses streaming by default for all file operations
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,13 @@ impl LtHash<B, N> {
     fn new() -> Result<Self, LtHashError>;
     fn with_checksum(checksum: &[u8]) -> Result<Self, LtHashError>;
 
+    // In-memory operations
     fn add_object(&mut self, data: &[u8]) -> Result<&mut Self, LtHashError>;
     fn remove_object(&mut self, data: &[u8]) -> Result<&mut Self, LtHashError>;
+
+    // Streaming operations (for large files)
+    fn add_object_stream<R: Read>(&mut self, reader: R) -> Result<&mut Self, LtHashError>;
+    fn remove_object_stream<R: Read>(&mut self, reader: R) -> Result<&mut Self, LtHashError>;
 
     fn try_add(&mut self, other: &Self) -> Result<(), LtHashError>;  // Non-panicking
     fn try_sub(&mut self, other: &Self) -> Result<(), LtHashError>;  // Non-panicking


### PR DESCRIPTION
New methods for processing data without loading into memory:
- LtHash::add_object_stream<R: Read>()
- LtHash::remove_object_stream<R: Read>()
- Blake3Xof::update_reader<R: Read>()
- Blake2xb::update_reader<R: Read>()

Uses 8KB buffer for efficient I/O. CLI now uses streaming by default for all file operations, enabling processing of arbitrarily large files.

Added test verifying streaming produces identical results to in-memory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds streaming read support to LtHash and hash backends and updates the CLI to stream files by default, enabling large-file processing with constant memory.
> 
> - **Core (`src/lthash.rs`)**:
>   - Add streaming methods: `add_object_stream<R: Read>()`, `remove_object_stream<R: Read>()`.
>   - Implement `hash_reader_into_scratch` for both BLAKE3 and Blake2xb backends (8KB chunks).
> - **Backends**:
>   - `src/blake3_xof.rs`: Add `update_reader<R: Read>()` for chunked updates.
>   - `src/blake2xb.rs`: Add `update_reader<R: Read>()` for chunked updates.
> - **CLI (`src/bin/lthash_cli.rs`)**:
>   - Switch file/stdin handling to streaming via `add_object_stream`/`remove_object_stream`.
>   - Remove full-file reads; minor usage text tweaks.
> - **Tests (`tests/integration_test.rs`)**:
>   - Add `test_streaming_equals_inmemory` to verify streaming parity with in-memory ops.
> - **Docs**:
>   - `README.md` and `Claude.md`: Document new streaming API and default CLI behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a695e5d4df301f07ea939ae31a23e2fbc9674162. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->