### PR TITLE
Add cargo-mutants analysis: close test gaps and configure exclusions

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,72 @@
+# cargo-mutants configuration
+# Run with: cargo mutants
+# See https://mutants.rs/ for documentation
+
+# Binary targets are not covered by unit/integration tests
+exclude_globs = ["src/bin/**"]
+
+# Regex patterns for mutants that cannot be caught by tests.
+# Each pattern matches against the full mutant description, formatted as:
+#   "file.rs:LINE:COL: replace X with Y in FunctionName"
+exclude_re = [
+    # ------------------------------------------------------------------------
+    # Code only compiled with the `folly-compat` feature (requires libsodium C
+    # library). The default feature set is `blake3-backend` + `parallel`, so
+    # none of this code is compiled or testable in a standard `cargo test` run.
+    # To test these, run: cargo mutants --features folly-compat
+    # ------------------------------------------------------------------------
+    "blake2xb\\.rs",
+
+    # ------------------------------------------------------------------------
+    # cfg-gated overloads in lthash.rs that share names with the default
+    # (tested) versions. These are only compiled with `folly-compat` or
+    # `not(parallel)`, making them unreachable with default features.
+    #
+    # We exclude by line number since the function names collide with tested
+    # code. If line numbers drift, cargo-mutants will report these as missed
+    # again; grep for #[cfg(feature = "folly-compat")] or
+    # #[cfg(not(feature = "parallel"))] to find the current locations.
+    # ------------------------------------------------------------------------
+    "lthash\\.rs:230:",  # folly-compat set_key
+    "lthash\\.rs:501:",  # not(parallel) add_all
+    "lthash\\.rs:558:",  # not(parallel) remove_all
+    "lthash\\.rs:661:",  # folly-compat hash_into_scratch
+    "lthash\\.rs:684:",  # folly-compat hash_reader_into_scratch
+    "lthash\\.rs:714:",  # folly-compat hash_data_to_vec
+    "lthash\\.rs:750:",  # folly-compat hash_reader_to_vec
+
+    # ------------------------------------------------------------------------
+    # Dead code by design: MAX_OUTPUT_LENGTH is usize::MAX for BLAKE3, so the
+    # comparison `output_length > usize::MAX` is always false. The code comment
+    # at blake3_xof.rs:72 explicitly states this is kept only for API
+    # consistency with Blake2xb.
+    # ------------------------------------------------------------------------
+    "replace > with == in Blake3Xof::init",
+    "replace > with >= in Blake3Xof::init",
+
+    # ------------------------------------------------------------------------
+    # Mathematically equivalent mutants: `result_a | result_b` and
+    # `result_a ^ result_b` produce identical output when result_a and result_b
+    # have no overlapping set bits. The masks (mask_a, mask_b) are complements,
+    # guaranteeing disjoint bits, so OR and XOR are provably equivalent here.
+    # No test can distinguish these mutants.
+    # ------------------------------------------------------------------------
+    "replace \\| with \\^ in .*add_with_mask",
+    "replace \\| with \\^ in .*subtract_with_mask",
+
+    # ------------------------------------------------------------------------
+    # Unobservable optimization: has_padding_bits() returning true for B=16/32
+    # causes clear_padding_bits() to run, but since data_mask() is all-ones for
+    # those element sizes, `value &= 0xffff_ffff_ffff_ffff` is a no-op.
+    # The early-return is purely a performance optimization.
+    # ------------------------------------------------------------------------
+    "has_padding_bits -> bool with true",
+
+    # ------------------------------------------------------------------------
+    # Drop impl zeroizes memory for defense-in-depth. Zeroization is a security
+    # best practice but cannot be observed from within the test process after
+    # deallocation (the memory is gone). Skipping Drop has no functional
+    # effect on hash correctness.
+    # ------------------------------------------------------------------------
+    "impl Drop.*drop",
+]

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 Cargo.lock
 **/*.rs.bk
 
+# cargo-mutants
+/mutants.out*/
+
 # IDE
 .vscode/
 .idea/

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,4 +1,4 @@
-use lthash::{LtHash16_1024, LtHashError};
+use lthash::{LtHash, LtHash16_1024, LtHashError};
 
 #[cfg(feature = "folly-compat")]
 use lthash::Blake2xb;
@@ -1484,4 +1484,149 @@ fn test_blake3_xof_keyed_streaming() {
     Blake3Xof::hash(&mut oneshot_output, b"hello world", &key, &[], &[]).unwrap();
 
     assert_eq!(streaming_output, oneshot_output);
+}
+
+// ============================================================================
+// Tests added based on cargo-mutants analysis to close test coverage gaps
+// ============================================================================
+
+/// Test that invalid element count (too small) is rejected.
+/// Catches mutant: compile_time_checks replaced with Ok(()).
+#[test]
+fn test_invalid_element_count_too_small() {
+    // N must be >= 1000; these should all fail validation
+    assert!(
+        LtHash::<16, 100>::new().is_err(),
+        "N=100 should be rejected (< 1000)"
+    );
+    assert!(
+        LtHash::<16, 999>::new().is_err(),
+        "N=999 should be rejected (< 1000)"
+    );
+    assert!(
+        LtHash::<20, 999>::new().is_err(),
+        "N=999 should be rejected for B=20"
+    );
+    // Verify the boundary: N=1000 with B=16 should be accepted (1000 % 4 == 0)
+    assert!(
+        LtHash::<16, 1000>::new().is_ok(),
+        "N=1000 should be accepted"
+    );
+}
+
+/// Test that element count not divisible by elements_per_u64 is rejected.
+/// Catches mutant: compile_time_checks replaced with Ok(()).
+#[test]
+fn test_invalid_element_count_not_divisible() {
+    // For B=16, elements_per_u64=4, so N must be divisible by 4
+    assert!(
+        LtHash::<16, 1001>::new().is_err(),
+        "N=1001 should be rejected for B=16 (not divisible by 4)"
+    );
+    assert!(
+        LtHash::<16, 1002>::new().is_err(),
+        "N=1002 should be rejected for B=16 (not divisible by 4)"
+    );
+    assert!(
+        LtHash::<16, 1003>::new().is_err(),
+        "N=1003 should be rejected for B=16 (not divisible by 4)"
+    );
+
+    // For B=20, elements_per_u64=3, so N must be divisible by 3
+    assert!(
+        LtHash::<20, 1000>::new().is_err(),
+        "N=1000 should be rejected for B=20 (not divisible by 3)"
+    );
+    assert!(
+        LtHash::<20, 1001>::new().is_err(),
+        "N=1001 should be rejected for B=20 (not divisible by 3)"
+    );
+
+    // For B=32, elements_per_u64=2, so N must be divisible by 2
+    assert!(
+        LtHash::<32, 1001>::new().is_err(),
+        "N=1001 should be rejected for B=32 (not divisible by 2)"
+    );
+}
+
+/// Test that with_checksum also validates parameters.
+/// Catches mutant: compile_time_checks replaced with Ok(()).
+#[test]
+fn test_with_checksum_validates_params() {
+    let checksum = vec![0u8; 200];
+    assert!(
+        LtHash::<16, 100>::with_checksum(&checksum).is_err(),
+        "with_checksum should reject invalid N"
+    );
+}
+
+/// Test that update_reader returns the correct byte count.
+/// Catches mutant: total_bytes += replaced with *= (0 * n stays 0).
+#[cfg(feature = "blake3-backend")]
+#[test]
+fn test_update_reader_byte_count() {
+    let data = b"The quick brown fox jumps over the lazy dog"; // 43 bytes
+
+    let mut xof = Blake3Xof::new();
+    xof.init(64, &[], &[], &[]).unwrap();
+    let bytes_read = xof
+        .update_reader(std::io::Cursor::new(&data[..]))
+        .unwrap();
+
+    assert_eq!(
+        bytes_read, 43,
+        "update_reader should return exact byte count"
+    );
+}
+
+/// Test update_reader byte count with data larger than the internal buffer.
+/// Ensures the += accumulation is correct across multiple read iterations.
+#[cfg(feature = "blake3-backend")]
+#[test]
+fn test_update_reader_byte_count_multi_chunk() {
+    // Data larger than the 64KB internal buffer to force multiple iterations
+    let data = vec![0x42u8; 150_000];
+
+    let mut xof = Blake3Xof::new();
+    xof.init(64, &[], &[], &[]).unwrap();
+    let bytes_read = xof
+        .update_reader(std::io::Cursor::new(&data))
+        .unwrap();
+
+    assert_eq!(
+        bytes_read, 150_000,
+        "update_reader should correctly accumulate bytes across chunks"
+    );
+}
+
+/// Test update_reader byte count after calling finish should fail.
+/// Catches mutant: update_reader replaced with Ok(0) when finished.
+#[cfg(feature = "blake3-backend")]
+#[test]
+fn test_update_reader_after_finish() {
+    let mut xof = Blake3Xof::new();
+    xof.init(64, &[], &[], &[]).unwrap();
+    xof.update(b"data").unwrap();
+    let mut output = [0u8; 64];
+    xof.finish(&mut output).unwrap();
+
+    // update_reader after finish should fail
+    let result = xof.update_reader(std::io::Cursor::new(b"more"));
+    assert!(
+        result.is_err(),
+        "update_reader after finish should return an error"
+    );
+}
+
+/// Test update_reader before init should fail.
+/// Catches mutant: update_reader replaced with Ok(0) when not initialized.
+#[cfg(feature = "blake3-backend")]
+#[test]
+fn test_update_reader_before_init() {
+    let mut xof = Blake3Xof::new();
+    let result = xof.update_reader(std::io::Cursor::new(b"data"));
+    assert!(
+        result.is_err(),
+        "update_reader before init should return an error"
+    );
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1569,9 +1569,7 @@ fn test_update_reader_byte_count() {
 
     let mut xof = Blake3Xof::new();
     xof.init(64, &[], &[], &[]).unwrap();
-    let bytes_read = xof
-        .update_reader(std::io::Cursor::new(&data[..]))
-        .unwrap();
+    let bytes_read = xof.update_reader(std::io::Cursor::new(&data[..])).unwrap();
 
     assert_eq!(
         bytes_read, 43,
@@ -1589,9 +1587,7 @@ fn test_update_reader_byte_count_multi_chunk() {
 
     let mut xof = Blake3Xof::new();
     xof.init(64, &[], &[], &[]).unwrap();
-    let bytes_read = xof
-        .update_reader(std::io::Cursor::new(&data))
-        .unwrap();
+    let bytes_read = xof.update_reader(std::io::Cursor::new(&data)).unwrap();
 
     assert_eq!(
         bytes_read, 150_000,


### PR DESCRIPTION
## Summary

Mutation testing with `cargo-mutants` revealed **97 missed mutants** out of 291 in library code. After analysis, these break down into **2 real test gaps** plus a large number of mutants that are impossible or impractical to test.

### Before → After
| Metric | Before | After |
|---|---|---|
| Total mutants | 291 | 196 |
| Missed | 97 | **0** |
| Caught | 190 | 192 |
| Unviable | 4 | 4 |

---

## Real test gaps closed (2 new mutants caught)

### 1. `compile_time_checks()` could be replaced with `Ok(())`
No test ever constructed an `LtHash` with invalid const generic parameters, so replacing the entire validation function with `Ok(())` passed all tests.

**Fix**: Added tests that verify:
- `LtHash::<16, 100>::new()` is rejected (`N < 1000`)
- `LtHash::<16, 999>::new()` is rejected (boundary)
- `LtHash::<16, 1001>::new()` is rejected (`N` not divisible by 4)
- `LtHash::<20, 1000>::new()` is rejected (`N` not divisible by 3)
- `LtHash::<32, 1001>::new()` is rejected (`N` not divisible by 2)
- `LtHash::<16, 1000>::new()` is accepted (boundary)

### 2. `Blake3Xof::update_reader()` return value never asserted
The `total_bytes` return value was never checked. The `+=` → `*=` mutant survived because `0 * n` stays `0` without panicking (unlike `-=` which was caught by overflow panic).

**Fix**: Added tests that verify the byte count is correct for single-chunk (43 bytes) and multi-chunk (150 KB > 64 KB buffer) reads, plus state validation (uninit/finished).

---

## Excluded mutants (`.cargo/mutants.toml`)

All remaining "missed" mutants are now explicitly excluded with documentation:

| Category | Count | Reason |
|---|---|---|
| `src/bin/**` | 256 | CLI binaries have no unit test coverage |
| `blake2xb.rs` | 69 | Only compiled with `--features folly-compat` (libsodium dep) |
| folly-compat cfg-gated fns in `lthash.rs` | 16 | Same — `set_key`, `hash_*_to_vec`, etc. overloads |
| `not(parallel)` fallback fns | 2 | Only compiled with `--no-default-features` |
| `output_length > usize::MAX` check | 2 | Always false; kept only for API symmetry with Blake2xb (see comment in code) |
| `result_a \| result_b` → `^` | 4 | Mathematically equivalent: masks guarantee disjoint bits, so OR == XOR |
| `has_padding_bits() → true` | 1 | No-op: `data_mask` is all-ones for B=16/32, so the extra AND is harmless |
| `Drop::drop() → ()` | 1 | Zeroization is a security defense; not observable after deallocation |

---

## Running mutation tests

```bash
cargo install cargo-mutants
cargo mutants
```

The config in `.cargo/mutants.toml` is automatically picked up.

For folly-compat coverage (requires libsodium):
```bash
cargo mutants --features folly-compat --exclude-re ""
```
